### PR TITLE
Ignore emacs tempfiles

### DIFF
--- a/lib/jitter.js
+++ b/lib/jitter.js
@@ -98,6 +98,9 @@
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       item = _ref[_i];
       sourcePath = "" + source + "/" + item;
+      if (item.indexOf(".#") === 0) {
+        continue;
+      }
       if (isWatched[sourcePath]) {
         continue;
       }

--- a/src/jitter.coffee
+++ b/src/jitter.coffee
@@ -91,6 +91,7 @@ compileScripts= (options) ->
 compile= (source, target, options) ->
   for item in fs.readdirSync source
     sourcePath= "#{source}/#{item}"
+    continue if item.indexOf(".#") is 0
     continue if isWatched[sourcePath]
     if path.extname(sourcePath) is '.coffee'
       readScript sourcePath, target, options


### PR DESCRIPTION
Hello,

Jitter was compiling Emacs temporary save files, like so:

Watching for changes and new files. Press Ctrl+C to stop.
EBADF, Bad file descriptor 'src/.#animator.coffee'
Compiled src/.#animator.coffee

So, I patched it to ignore files starting with the ".#" prefix. It may be useful to ignore all dotfiles, but I didn't want to make that assumption on your part :)

-Ken
