### PR TITLE
Bug fix: occasionally Jitter crashes when compiling short-life files

### DIFF
--- a/lib/jitter.js
+++ b/lib/jitter.js
@@ -104,7 +104,17 @@
       if (isWatched[sourcePath]) {
         continue;
       }
-      _results.push(path.extname(sourcePath) === '.coffee' ? readScript(sourcePath, target, options) : fs.statSync(sourcePath).isDirectory() ? compile(sourcePath, target, options) : void 0);
+      _results.push((function() {
+        try {
+          if (path.extname(sourcePath) === '.coffee') {
+            return readScript(sourcePath, target, options);
+          } else if (fs.statSync(sourcePath).isDirectory()) {
+            return compile(sourcePath, target, options);
+          }
+        } catch (e) {
+
+        }
+      })());
     }
     return _results;
   };

--- a/src/jitter.coffee
+++ b/src/jitter.coffee
@@ -93,10 +93,12 @@ compile= (source, target, options) ->
     sourcePath= "#{source}/#{item}"
     continue if item[0] is '.'
     continue if isWatched[sourcePath]
-    if path.extname(sourcePath) is '.coffee'
-      readScript sourcePath, target, options
-    else if fs.statSync(sourcePath).isDirectory()
-      compile sourcePath, target, options
+    try
+      if path.extname(sourcePath) is '.coffee'
+        readScript sourcePath, target, options
+      else if fs.statSync(sourcePath).isDirectory()
+        compile sourcePath, target, options
+    catch e
     
 rootCompile= (options) ->
   compile(baseSource, baseTarget, options)


### PR DESCRIPTION
Hi, I've encountered Jitter crashing several times.
I found that it is caused by short-life files on source directory.
