### PR TITLE
Make Jitter work on Linux with Vim

### DIFF
--- a/lib/jitter.js
+++ b/lib/jitter.js
@@ -34,7 +34,7 @@
     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     OTHER DEALINGS IN THE SOFTWARE.
-  */  var BANNER, CoffeeScript, baseSource, baseTarget, baseTest, compile, compileScript, compileScripts, die, exec, fs, isSubpath, isWatched, jsPath, notifyGrowl, optionParser, options, optparse, parseOptions, path, print, puts, q, readScript, rootCompile, runTests, testFiles, usage, watchScript, writeJS, _ref;
+  */  var BANNER, CoffeeScript, baseSource, baseTarget, baseTest, compile, compileScript, compileScripts, die, exec, fileRevisions, fs, isSubpath, isWatched, jsPath, notifyGrowl, optionParser, options, optparse, parseOptions, path, print, puts, q, readScript, rootCompile, runTests, syncCompileScript, testFiles, usage, watchScript, writeJS, _ref;
   var __indexOf = Array.prototype.indexOf || function(item) {
     for (var i = 0, l = this.length; i < l; i++) {
       if (this[i] === item) return i;
@@ -54,6 +54,7 @@
   optionParser = null;
   isWatched = {};
   testFiles = [];
+  fileRevisions = {};
   exports.run = function() {
     options = parseOptions();
     if (!baseTarget) {
@@ -137,12 +138,22 @@
       persistent: true,
       interval: 250
     }, function(curr, prev) {
-      if (curr.mtime.getTime() === prev.mtime.getTime()) {
+      if (curr.mtime.getTime() === prev.mtime.getTime() && curr.size === prev.size) {
         return;
       }
-      compileScript(source, target, options);
-      return q(runTests);
+      return syncCompileScript(source, target, options);
     });
+  };
+  syncCompileScript = function(source, target, options) {
+    var id, _ref2;
+    id = (_ref2 = fileRevisions[source]) != null ? _ref2 : 0;
+    fileRevisions[source] = ++id;
+    return setTimeout(function() {
+      if (fileRevisions[source] === id) {
+        compileScript(source, target, options);
+        return q(runTests);
+      }
+    }, 50);
   };
   compileScript = function(source, target, options) {
     var code, currentJS, js, targetPath;


### PR DESCRIPTION
On Linux, Jitter appears to run normally without Growl notifications but sometimes it produces blank JavaScript while using Vim.
I investigated it and found that it caused by the fact that fs.watchFile() fires callback several times for every single file save. nlink/mtime/size stat changes are separated into these events.

Postponing compilation until after the sequence of several stat changes makes Jitter work correctly.
#### Tested environments
- Vim 7.1 on Debian 5.0
- Vim 7.3 on CentOS 5.6
