### PR TITLE
Allow extensions other than .coffee

### DIFF
--- a/src/jitter.coffee
+++ b/src/jitter.coffee
@@ -94,7 +94,7 @@ compile= (source, target, options) ->
     continue if item[0] is '.'
     continue if isWatched[sourcePath]
     try
-      if path.extname(sourcePath) is '.coffee'
+      if path.extname(sourcePath)[1..] in options?.extensions.split(',') ? ['coffee']
         readScript sourcePath, target, options
       else if fs.statSync(sourcePath).isDirectory()
         compile sourcePath, target, options
@@ -165,6 +165,7 @@ runTests= ->
 parseOptions= ->
   optionParser= new optparse.OptionParser [
       ['-b', '--bare', 'compile without the top-level function wrapper']
+      ['-e', '--extensions', 'allowed file extensions, e.g. coffee,cof']
   ], BANNER
   options=    optionParser.parse process.argv
   [baseSource, baseTarget, baseTest]= (options.arguments[arg] or '' for arg in [2..4])

--- a/src/jitter.coffee
+++ b/src/jitter.coffee
@@ -94,7 +94,7 @@ compile= (source, target, options) ->
     continue if item[0] is '.'
     continue if isWatched[sourcePath]
     try
-      if path.extname(sourcePath)[1..] in options?.extensions.split(',') ? ['coffee']
+      if path.extname(sourcePath)[1..] in options?.extension ? ['coffee']
         readScript sourcePath, target, options
       else if fs.statSync(sourcePath).isDirectory()
         compile sourcePath, target, options
@@ -165,7 +165,7 @@ runTests= ->
 parseOptions= ->
   optionParser= new optparse.OptionParser [
       ['-b', '--bare', 'compile without the top-level function wrapper']
-      ['-e', '--extensions', 'allowed file extensions, e.g. coffee,cof']
+      ['-e', '--extension [ext*]', 'allowed file extension, e.g. -e coffee -e cof']
   ], BANNER
   options=    optionParser.parse process.argv
   [baseSource, baseTarget, baseTest]= (options.arguments[arg] or '' for arg in [2..4])


### PR DESCRIPTION
I've been wanting to use Jitter for a long time but I couldn't because it was hard-wired to only look for .coffee extensions.  I've used .cof extensions for a year now and Jitter was the first utility that had a problem with that.

This mod has a new command-line option: 

```
-e, --extension     allowed file extension, e.g. -e coffee -e cof
```

The example of `-e coffee -e cof` will find both extensions.  I've tested it in a single directory of mixed extensions.

Of course leaving out the option defaults to just `.coffee`.

P.S.  I didn't really know how to use optparse.  I specified this rule:

```
['-e', '--extension [ext*]', 'allowed file extension, e.g. -e coffee -e cof']
```

It seems to work as I indicated above.  However, there must be a better way to specify two extensions than using `-e` twice.  If anyone knows how let me know.

P.P.S. I just bought your book, which is what inspired me to finally use jitter.
