### PR TITLE
test coffeescript files directly, assume 'test' dir, spawn node server on successful compile

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,11 @@
+# Fork Notes
+
+This variant of Jitter will automatically run 'npm test' after a
+successful compilation.
+
+If passed a third parameter, node will be started with the script
+at this path.
+
 # Jitter
 
 Simple continuous compilation for [CoffeeScript](http://coffeescript.org), from the author

--- a/lib/jitter.js
+++ b/lib/jitter.js
@@ -1,44 +1,43 @@
+
+/*
+  Jitter, a CoffeeScript compilation utility
+
+  The latest version and documentation, can be found at:
+  http://github.com/TrevorBurnham/Jitter
+
+  Copyright (c) 2010 Trevor Burnham
+  http://iterative.ly
+
+  Based on command.coffee by Jeremy Ashkenas
+  http://jashkenas.github.com/coffee-script/documentation/docs/command.html
+
+  Growl notification code contributed by Andrey Tarantsov
+  http://www.tarantsov.com/
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 (function() {
-
-  /*
-    Jitter, a CoffeeScript compilation utility
-  
-    The latest version and documentation, can be found at:
-    http://github.com/TrevorBurnham/Jitter
-  
-    Copyright (c) 2010 Trevor Burnham
-    http://iterative.ly
-  
-    Based on command.coffee by Jeremy Ashkenas
-    http://jashkenas.github.com/coffee-script/documentation/docs/command.html
-  
-    Growl notification code contributed by Andrey Tarantsov
-    http://www.tarantsov.com/
-  
-    Permission is hereby granted, free of charge, to any person
-    obtaining a copy of this software and associated documentation
-    files (the "Software"), to deal in the Software without
-    restriction, including without limitation the rights to use,
-    copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the
-    Software is furnished to do so, subject to the following
-    conditions:
-  
-    The above copyright notice and this permission notice shall be
-    included in all copies or substantial portions of the Software.
-  
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-    HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-  */
-
-  var BANNER, CoffeeScript, baseSource, baseTarget, baseTest, compile, compileScript, compileScripts, die, exec, fs, isSubpath, isWatched, jsPath, notify, optionParser, options, optparse, parseOptions, path, print, puts, q, readScript, rootCompile, runTests, target_ext, targetlib, testFiles, usage, watchScript, writeJS, _ref;
-  var __hasProp = Object.prototype.hasOwnProperty, __indexOf = Array.prototype.indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (__hasProp.call(this, i) && this[i] === item) return i; } return -1; };
+  var BANNER, CoffeeScript, baseSource, baseTarget, compile, compileScript, compileScripts, die, exec, fs, isSubpath, isWatched, jsPath, nodeProcess, nodeStartScript, notify, optionParser, options, optparse, parseOptions, path, print, puts, q, readScript, rootCompile, runNodeStartScript, target_ext, targetlib, usage, watchScript, writeJS, _ref;
 
   fs = require('fs');
 
@@ -68,17 +67,19 @@
 
   q = require('sink').q;
 
-  BANNER = 'Jitter takes a directory of *.coffee files and recursively compiles\nthem to *.js files, preserving the original directory structure.\n\nJitter also watches for changes and automatically recompiles as\nneeded. It even detects new files, unlike the coffee utility.\n\nIf passed a test directory, it will run each test through node on\neach change.\n\nUsage:\n  jitter coffee-path js-path [test-path]';
+  BANNER = 'Jitter takes a directory of *.coffee files and recursively compiles\nthem to *.js files, preserving the original directory structure.\n\nJitter also watches for changes and automatically recompiles as\nneeded. It even detects new files, unlike the coffee utility.\n\nThis variant of Jitter will automatically run \'npm test\' after a\nsuccessful compilation.\n\nIf passed a third parameter, node will be started with the script\nat this path.\n\nUsage:\n  jitter coffee-path js-path [nodeStartScript]';
 
   options = {};
 
-  baseSource = baseTarget = baseTest = '';
+  baseSource = baseTarget = '';
 
   optionParser = null;
 
   isWatched = {};
 
-  testFiles = [];
+  nodeStartScript = '';
+
+  nodeProcess = null;
 
   exports.run = function() {
     options = parseOptions();
@@ -92,7 +93,6 @@
       Source: baseSource,
       Target: baseTarget
     };
-    if (baseTest) dirs.Test = baseTest;
     for (name in dirs) {
       dir = dirs[name];
       q(path.exists, dir, function(exists) {
@@ -106,7 +106,7 @@
     q(function() {
       return rootCompile(options);
     });
-    q(runTests);
+    q(runNodeStartScript);
     return q(function() {
       puts('Watching for changes and new files. Press Ctrl+C to stop.');
       return setInterval(function() {
@@ -140,8 +140,7 @@
   };
 
   rootCompile = function(options) {
-    compile(baseSource, baseTarget, options);
-    if (baseTest) return compile(baseTest, baseTest, options);
+    return compile(baseSource, baseTarget, options);
   };
 
   readScript = function(source, target, options) {
@@ -158,7 +157,8 @@
     }, function(curr, prev) {
       if (curr.mtime.getTime() === prev.mtime.getTime()) return;
       compileScript(source, target, options);
-      return q(runTests);
+      puts('fwee');
+      return q(runNodeStartScript);
     });
   };
 
@@ -188,19 +188,15 @@
   };
 
   jsPath = function(source, target) {
-    var base, dir, filename;
-    base = target === baseTest ? baseTest : baseSource;
+    var dir, filename;
     filename = path.basename(source, path.extname(source)) + '.js';
-    dir = target + path.dirname(source).substring(base.length);
+    dir = target + path.dirname(source).substring(baseSource.length);
     return path.join(dir, filename);
   };
 
   writeJS = function(js, targetPath) {
     return q(exec, "mkdir -p " + (path.dirname(targetPath)), function() {
-      fs.writeFileSync(targetPath, js);
-      if (baseTest && isSubpath(baseTest, targetPath) && (__indexOf.call(testFiles, targetPath) < 0)) {
-        return testFiles.push(targetPath);
-      }
+      return fs.writeFileSync(targetPath, js);
     });
   };
 
@@ -221,19 +217,28 @@
     }
   };
 
-  runTests = function() {
-    var test, _i, _len, _results;
-    _results = [];
-    for (_i = 0, _len = testFiles.length; _i < _len; _i++) {
-      test = testFiles[_i];
-      puts("Running " + test);
-      _results.push(exec("node " + test, function(error, stdout, stderr) {
-        print(stdout);
-        print(stderr);
-        if (stderr) return notify(test, stderr);
-      }));
-    }
-    return _results;
+  runNodeStartScript = function() {
+    var testProcess;
+    testProcess = spawn("npm", ["test"]);
+    testProcess.stdout.on('data', function(data) {
+      return print(data);
+    });
+    testProcess.stderr.on('data', function(data) {
+      return print(data);
+    });
+    return testProcess.on('exit', function(code) {
+      if (nodeProcess) nodeProcess.kill();
+      if (nodeStartScript) {
+        nodeProcess = spawn("node", [nodeStartScript]);
+        nodeProcess.stdout.on('data', function(data) {
+          return print(data);
+        });
+        nodeProcess.stderr.on('data', function(data) {
+          return print(data);
+        });
+        return nodeProcess.on('exit', function(code) {});
+      }
+    });
   };
 
   parseOptions = function() {
@@ -247,7 +252,7 @@
         _results.push(options.arguments[arg] || '');
       }
       return _results;
-    })(), baseSource = _ref2[0], baseTarget = _ref2[1], baseTest = _ref2[2];
+    })(), baseSource = _ref2[0], baseTarget = _ref2[1], nodeStartScript = _ref2[2];
     if (/\/$/.test(baseSource)) {
       baseSource = baseSource.substr(0, baseSource.length - 1);
     }

--- a/lib/jitter.js
+++ b/lib/jitter.js
@@ -37,7 +37,7 @@
 */
 
 (function() {
-  var BANNER, CoffeeScript, baseSource, baseTarget, compile, compileScript, compileScripts, die, exec, fs, isSubpath, isWatched, jsPath, nodeProcess, nodeStartScript, notify, optionParser, options, optparse, parseOptions, path, print, puts, q, readScript, rootCompile, runNodeStartScript, target_ext, targetlib, usage, watchScript, writeJS, _ref;
+  var BANNER, CoffeeScript, baseSource, baseTarget, compile, compileScript, compileScripts, die, exec, fs, isSubpath, isWatched, jsPath, nodeProcess, nodeStartScript, notify, optionParser, options, optparse, parseOptions, path, print, puts, q, readScript, rootCompile, runNodeStartScript, spawn, target_ext, targetlib, usage, watchScript, writeJS, _ref;
 
   fs = require('fs');
 
@@ -56,6 +56,8 @@
   CoffeeScript = require(targetlib);
 
   exec = require('child_process').exec;
+
+  spawn = require('child_process').spawn;
 
   _ref = (function() {
     try {

--- a/src/jitter.coffee
+++ b/src/jitter.coffee
@@ -49,6 +49,7 @@ else
 
 CoffeeScript=  require targetlib
 {exec}=        require 'child_process'
+{spawn}=         require 'child_process'
 {puts, print}= try require 'util' catch e then require 'sys'
 {q}=           require 'sink'
 


### PR DESCRIPTION
Hi trevor, thanks for the work on jitter.

In case it's of use to you, my fork here does the following, per the readme:

---
# Fork Notes

This variant of Jitter will automatically run 'npm test' after a
successful compilation.

If passed a third parameter, node will be started with the script
at this path.

---

Additionally, coffeescript tests are no longer compiled into javascript beforehand. The latest vows builds don't require it.

Here was my reasoning:
- I personally didn't see any case where I would deviate from the standard of having a 'test' directory in the project root. So I'm relying on 'npm test' to figure it out for me.
- I found it more useful to have my node server restarted each time jitter recompiled the coffeescript files. Previously I had to pair jitter with nodemon to get the same effect.

That's all... I recognize this breaks previous functionality so it's more of a ping than a pull request.

Happy holidays.
